### PR TITLE
Changed default gravity from -2205 to -1960.

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -38,7 +38,7 @@ GlobalDefaultGameMode=/Game/NewStreak/Blueprints/BP_FPSGamemode.BP_FPSGamemode_C
 GlobalDefaultServerGameMode=None
 
 [/Script/Engine.PhysicsSettings]
-DefaultGravityZ=-2205.000000
+DefaultGravityZ=-1960.000000
 DefaultTerminalVelocity=4000.000000
 DefaultFluidFriction=0.300000
 SimulateScratchMemorySize=262144


### PR DESCRIPTION
This means it's now 2x default instead of the previous semi-arbitrary 2.25x.
It comes from a comment by @lrl64 that Jitspoe said LB's gravity was 2x real-world gravity.
Assuming he's not scaling that by the LB:UE4 distance scale difference, this should be
the "correct" value.

It still feels fine to me, at any rate, so I'll take it.  :)